### PR TITLE
Add Region Jakarta Indonesia

### DIFF
--- a/ClientApp/src/assets/data/regions.json
+++ b/ClientApp/src/assets/data/regions.json
@@ -119,6 +119,19 @@
   {
     "availabilityZoneCount": 0,
     "availabilityZoneStatus": null,
+    "displayName": "Jakarta",
+    "geography": "Asia Pacific",
+    "latitude": null,
+    "longitude": null,
+    "pairedRegion": null,
+    "physicalLocation": null,
+    "regionalDisplayName": null,
+    "regionName": "ap-southeast-3",
+    "storageAccountName": "astap-southeast-3"
+  },
+  {
+    "availabilityZoneCount": 0,
+    "availabilityZoneStatus": null,
     "displayName": "Sydney",
     "geography": "Asia Pacific",
     "latitude": null,


### PR DESCRIPTION
AWS is now available for the Jakarta, Indonesia region. Lots of AWS users from Indonesia. I think adding the Jakarta region will really help AWS users in Indonesia. ❤️