### PR TITLE
Add new region Asia Pacific (Malaysia) ap-southeast-5

### DIFF
--- a/ClientApp/src/assets/data/geographies.json
+++ b/ClientApp/src/assets/data/geographies.json
@@ -138,6 +138,18 @@
         "name": "ap-southeast-4",
         "availabilityZoneCount": 4,
         "restricted": false
+      },
+      {
+        "displayName": "Asia Pacific (Malaysia)",
+        "geography": "Asia Pacific",
+        "latitude": null,
+        "longitude": null,
+        "pairedRegion": null,
+        "physicalLocation": "Malaysia",
+        "regionalDisplayName": null,
+        "name": "ap-southeast-5",
+        "availabilityZoneCount": 3,
+        "restricted": false
       }
     ]
   },

--- a/ClientApp/src/assets/data/regions.json
+++ b/ClientApp/src/assets/data/regions.json
@@ -132,6 +132,18 @@
     "restricted": false
   },
   {
+    "displayName": "Asia Pacific (Malaysia)",
+    "geography": "Asia Pacific",
+    "latitude": null,
+    "longitude": null,
+    "pairedRegion": null,
+    "physicalLocation": "Malaysia",
+    "regionalDisplayName": null,
+    "name": "ap-southeast-5",
+    "availabilityZoneCount": 3,
+    "restricted": false
+  },
+  {
     "displayName": "Canada (Central)",
     "geography": "Canada",
     "latitude": null,


### PR DESCRIPTION
# Add new region Asia Pacific (Malaysia) ap-southeast-5

## Background

[AWS support new region in Malaysia](https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-malaysia-region/) since the project is really clean, I added a small PR so we can check this Malaysia region.

## Tests

1. Malaysia option added

<img width="1499" alt="image" src="https://github.com/user-attachments/assets/2d9e4fcc-9329-480c-84f4-678eb3540500">

2. Malaysia latest test displayed

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/9a62cd0c-a838-4936-b93b-ff540bcbd3b9">


